### PR TITLE
fix: fix zip() spread bug and strip leading slash from glob() results

### DIFF
--- a/src/schema/entities.ts
+++ b/src/schema/entities.ts
@@ -35,11 +35,11 @@ function _readDirEntities(filePath: string): Record<string, string> {
   parts.pop()
   for (const part of parts) {
     const [entity, label] = part.split(/-(.+)/)
-    if (!entity) continue;
+    if (!entity) continue
     entities[entity] = label || 'NOENTITY'
   }
   return entities
 }
-  
+
 export const readEntities = memoize(_readEntities)
 export const readDirEntities = memoize(_readDirEntities)

--- a/src/schema/expressionLanguage.test.ts
+++ b/src/schema/expressionLanguage.test.ts
@@ -3,8 +3,8 @@ import {
   contextFunction,
   expressionFunctions,
   formatter,
+  glob,
   prepareContext,
-  glob
 } from './expressionLanguage.ts'
 import { dataFile, rootFileTree } from './fixtures.test.ts'
 import type { BIDSContext } from './context.ts'

--- a/src/schema/expressionLanguage.test.ts
+++ b/src/schema/expressionLanguage.test.ts
@@ -238,6 +238,43 @@ Deno.test('test expression functions', async (t) => {
       ]),
     )
   })
+  await t.step('zip function', () => {
+    const zip = expressionFunctions.zip
+    const array_equal = (a: any[], b: any[]) =>
+      a.length === b.length &&
+      a.every((v: any, i: number) =>
+        Array.isArray(v) && Array.isArray(b[i])
+          ? v.length === b[i].length && v.every((x: any, j: number) => x === b[i][j])
+          : v === b[i]
+      )
+    // Equal-length arrays: element-wise pairing
+    // @ts-ignore: zip type inference is too strict for test assertions
+    assert(array_equal(zip([1, 2, 3], [4, 5, 6]), [[1, 4], [2, 5], [3, 6]]))
+    // @ts-ignore
+    assert(array_equal(zip(['a', 'b'], ['c', 'd']), [['a', 'c'], ['b', 'd']]))
+    // Unequal-length arrays: shorter array pads with undefined
+    // @ts-ignore
+    const unequal = zip([1, 2], [3, 4, 5])
+    assert(unequal.length === 3)
+    // Empty arrays
+    // @ts-ignore
+    assert(array_equal(zip([], []), []))
+  })
+  await t.step('dirEntities context', () => {
+    // The context is created from dataFile at sub-01/ses-01/anat/sub-01_ses-01_T1w.nii.gz
+    // dirEntities should extract entities from directory components
+    assert(context.dirEntities.sub === '01')
+    assert(context.dirEntities.ses === '01')
+  })
+  await t.step('glob multi-level patterns', () => {
+    // Multi-level glob pattern matching sub-*/ses-* directories
+    const matches = glob.bind(context)('sub-*/ses-*')
+    assert(matches.length > 0)
+    // Paths should not have leading slash
+    assert(
+      matches.every((m: string) => m.startsWith('sub-') && m.includes('ses-')),
+    )
+  })
   await t.step('allequal function', () => {
     const allequal = expressionFunctions.allequal
     assert(allequal([1, 2, 1], [1, 2, 1]) === true)

--- a/src/schema/expressionLanguage.ts
+++ b/src/schema/expressionLanguage.ts
@@ -53,9 +53,9 @@ function _walk(tree: BIDSContext["dataset"]["tree"]): string[] {
 
 export function glob(this: BIDSContext, toMatch: string): string[] {
   toMatch = toMatch.startsWith('/') ? toMatch : `/${toMatch}`
-  let re = path.globToRegExp(toMatch)
-  let files = _walk(this.dataset.tree)
-  return files.filter(x => re.test(x))
+  const re = path.globToRegExp(toMatch)
+  const files = _walk(this.dataset.tree)
+  return files.filter((x) => re.test(x)).map((x) => x.replace(/^\//, ''))
 }
 
 
@@ -174,7 +174,7 @@ export const expressionFunctions = {
     return (a != null && b != null) && a.length === b.length && a.every((v, i) => v === b[i])
   },
   zip: <T extends any[]>(...args: T): T[][] => {
-    return Array.from(_zip(args))
+    return Array.from(_zip(...args))
   },
   glob: glob
 }

--- a/src/schema/expressionLanguage.ts
+++ b/src/schema/expressionLanguage.ts
@@ -1,7 +1,7 @@
 import type { BIDSContext } from './context.ts'
 import { memoize } from '../utils/memoize.ts'
 import { deepEquals } from '../utils/deepEquals.ts'
-import * as path from "@std/path";
+import * as path from '@std/path'
 
 function exists(this: BIDSContext, list: string[], rule: string = 'dataset'): number {
   if (list == null) {
@@ -39,13 +39,13 @@ function exists(this: BIDSContext, list: string[], rule: string = 'dataset'): nu
 }
 
 /* Simplified walk producing paths of directories and files as strings */
-function _walk(tree: BIDSContext["dataset"]["tree"]): string[] {
+function _walk(tree: BIDSContext['dataset']['tree']): string[] {
   let ret: string[] = []
-  tree.directories.map(dir => {
+  tree.directories.map((dir) => {
     ret.push(dir.path)
     ret.push(..._walk(dir))
   })
-  tree.files.map(file => {
+  tree.files.map((file) => {
     ret.push(file.path)
   })
   return ret
@@ -58,19 +58,18 @@ export function glob(this: BIDSContext, toMatch: string): string[] {
   return files.filter((x) => re.test(x)).map((x) => x.replace(/^\//, ''))
 }
 
-
 // Source: https://matyasfodor.com/blog/efficient-zip#how-javascript-could-do-it
-function* _zip <T extends any[]>(...iterables: T) {
+function* _zip<T extends any[]>(...iterables: T) {
   // Get the iterators
-  const iterators = iterables.map((iterable) => iterable[Symbol.iterator]());
+  const iterators = iterables.map((iterable) => iterable[Symbol.iterator]())
   // Keep track of the current iteration state in `iterStates`
-  let iterStates = iterators.map((iterator) => iterator.next());
+  let iterStates = iterators.map((iterator) => iterator.next())
   // Loop until none of the iterators are exhausted
   while (iterStates.some(({ done }) => !done)) {
     // The current values of the iterators are yielded
-    yield iterStates.map(({ value, done }) => (!done ? value : null));
+    yield iterStates.map(({ value, done }) => (!done ? value : null))
     // The current iterator states are updated from the iterator
-    iterStates = iterators.map((iterator) => iterator.next());
+    iterStates = iterators.map((iterator) => iterator.next())
   }
 }
 
@@ -97,7 +96,7 @@ export const expressionFunctions = {
       return false
     }
 
-    const intersection = a.filter((x) => b.some(y => deepEquals(y, x)))
+    const intersection = a.filter((x) => b.some((y) => deepEquals(y, x)))
     if (intersection.length === 0) {
       return false
     }
@@ -176,7 +175,7 @@ export const expressionFunctions = {
   zip: <T extends any[]>(...args: T): T[][] => {
     return Array.from(_zip(...args))
   },
-  glob: glob
+  glob: glob,
 }
 
 /**

--- a/src/utils/deepEquals.ts
+++ b/src/utils/deepEquals.ts
@@ -1,10 +1,10 @@
 export function deepEquals<T>(a: T, b: T): boolean {
   if (a === b) return true
- 
+
   if (a === null || b === null || typeof a !== 'object' || typeof b !== 'object') {
     return false
   }
- 
+
   if (Array.isArray(a) && Array.isArray(b)) {
     if (a.length !== b.length) return false
     for (let i = 0; i < a.length; i++) {
@@ -14,19 +14,19 @@ export function deepEquals<T>(a: T, b: T): boolean {
   } else if (Array.isArray(a) || Array.isArray(b)) {
     return false
   }
- 
+
   const aKeys = Object.keys(a) as (keyof T)[]
   const bKeys = Object.keys(b) as (keyof T)[]
- 
+
   if (aKeys.length !== bKeys.length) {
     return false
   }
- 
+
   for (const aKey of aKeys) {
     if (!(aKey in b) || !deepEquals(a[aKey], b[aKey])) {
       return false
     }
   }
- 
-  return true;
+
+  return true
 }


### PR DESCRIPTION
Sorry, I configured my setup to `deno fmt` at the same time.